### PR TITLE
Docker compose creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 __pycache__
 env
 .env
-secrets.env
+secrets/
 
 # Database
 stylometryproject/db.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 __pycache__
 env
 .env
+secrets.env
 secrets/
 
 # Database

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 __pycache__
 env
 .env
+secrets.env
 
 # Database
 stylometryproject/db.sqlite3

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy Project to Docker
-COPY . src
-WORKDIR /src/stylometryproject
+COPY stylometryproject /stylometryproject
+WORKDIR /stylometryproject
 
 # Expose Port 8000
 EXPOSE 8000
@@ -21,7 +21,7 @@ CMD ["runserver", "0.0.0.0:8000", "--noreload"]
 
 # Commands
 # docker build -t stylometryproject:latest .
-# docker run -p 8000:8000 stylometryproject:latest 
+# docker run -p 8000:8000 --env-file [env file] stylometryproject:latest 
 
 # docker login
 # docker tag stylometryproject:latest itprojectauthorguard/it-project:latest

--- a/README.md
+++ b/README.md
@@ -78,4 +78,24 @@ The app uses Docker to easily create a highly flexible and easy to deploy web se
 3. Deploy to any hosting service that supports docker containers. (AWS, Heroku, etc.)
 
 
+#### Docker Usage
+A docker image can be build with the command: `docker build -t stylometryproject .` from the repository root
 
+The environment for the application can be configured via the file `stylometryproject/.env` or files under `secrets/`
+Configurable ENV variables:
+	DATABASE_TYPE = postgresql or sqlite (for testing purposes only)
+	For postgresql: (all have generic default values)
+		RDS_DB_NAME
+		RDS_USERNAME
+		RDS_PASSWORD
+		RDS_HOSTNAME
+		RDS_PORT
+	
+	Required by Django:
+	SECRET_KEY (generate with `django.core.management.utils.get_random_secret_key()`)
+
+There is also a docker `compose.yaml` file included.
+It contains two services `authorguard` and `authorguard-sqlite`, the latter being for local testing purposes only.
+Services can be run with `docker compose run [service name]` or `docker compose up` to run the default.
+
+Environment variables can be configured via the `secrets/database.env` and `secrets/key.env` files, or by hardcoding into the `compose.yaml` file under each service.

--- a/README.md
+++ b/README.md
@@ -98,4 +98,6 @@ There is also a docker `compose.yaml` file included.
 It contains two services `authorguard` and `authorguard-sqlite`, the latter being for local testing purposes only.
 Services can be run with `docker compose run [service name]` or `docker compose up` to run the default.
 
-Environment variables can be configured via the `secrets/database.env` and `secrets/key.env` files, or by hardcoding into the `compose.yaml` file under each service.
+Environment variables can be configured via the `env_file` or `environment` attributes in the `compose.yaml`
+By default it takes a file called `secrets.env` in the main folder.
+NOTE: syntax for docker env files is slightly more restrictive than normal, make sure there are no spaces either side of the '=' and remove quotation marks from around the variables.

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,43 +5,17 @@ services:
     ports:
      - 8000:8000
     restart: on-failure
+    #environment:
+    # - DATABASE_TYPE=postgresql
+    # - RDS_DB_NAME=stylometry_database
+    # - RDS_USERNAME=stylometry
+    # - RDS_PASSWORD=password
+    # - RDS_HOSTNAME=localhost
+    # - RDS_PORT=5432
+    # - SECRET_KEY=[django secret key]
     env_file:
      - secrets/key.env
      - secrets/database.env
-    profiles:
-     - remotedb
-
-  authorguard-local:
-    image: stylometryproject
-    ports:
-      - 8000:8000
-    environment:
-     - RDS_ENGINE="django.db.backends.postgresql_psycopg2"
-     - RDS_DB_NAME="stylometry_database"
-     - RDS_USERNAME="stylometry"
-     - RDS_PASSWORD="password"
-     - RDS_HOSTNAME="localhost"
-     - RDS_PORT="5432"
-    env_file:
-     - secrets/key.env
-    profiles:
-     - local
-    depends_on:
-     - postgres-db
-  
-  postgres-db:
-    image: postgres
-    restart: always
-    environment:
-     - POSTGRES_USER="stylometry"
-     - POSTGRES_PASSWORD="password"
-     - POSTGRES_DB="stylometry_database"
-    volumes:
-     - ./db:/var/lib/postgresql/data
-    ports:
-     - 5432:5432
-    profiles:
-     - local
   
   authorguard-sqlite:
     image: stylometryproject

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,8 +14,7 @@ services:
     # - RDS_PORT=5432
     # - SECRET_KEY=[django secret key]
     env_file:
-     - secrets/key.env
-     - secrets/database.env
+     - secrets.env
   
   authorguard-sqlite:
     image: stylometryproject
@@ -26,6 +25,6 @@ services:
     environment:
      - DATABASE_TYPE=sqlite
     env_file:
-     - secrets/key.env
+     - secrets.env
     profiles:
      - test

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,8 +1,10 @@
 services:
   authorguard:
     image: stylometryproject
+    network_mode: host
     ports:
      - 8000:8000
+    restart: on-failure
     env_file:
      - secrets/key.env
      - secrets/database.env
@@ -42,14 +44,14 @@ services:
      - local
   
   authorguard-sqlite:
-    build: stylometryproject
+    image: stylometryproject
+    network_mode: host
     ports:
-     - 127.0.0.1:8000:8000
+     - 8000:8000
+    restart: on-failure
     environment:
      - DATABASE_TYPE=sqlite
     env_file:
      - secrets/key.env
     profiles:
      - test
-    volumes:
-      - stylometryproject/db.sqlite3:/stylometryproject/db.sqlite3

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,55 @@
+services:
+  authorguard:
+    image: stylometryproject
+    ports:
+     - 8000:8000
+    env_file:
+     - secrets/key.env
+     - secrets/database.env
+    profiles:
+     - remotedb
+
+  authorguard-local:
+    image: stylometryproject
+    ports:
+      - 8000:8000
+    environment:
+     - RDS_ENGINE="django.db.backends.postgresql_psycopg2"
+     - RDS_DB_NAME="stylometry_database"
+     - RDS_USERNAME="stylometry"
+     - RDS_PASSWORD="password"
+     - RDS_HOSTNAME="localhost"
+     - RDS_PORT="5432"
+    env_file:
+     - secrets/key.env
+    profiles:
+     - local
+    depends_on:
+     - postgres-db
+  
+  postgres-db:
+    image: postgres
+    restart: always
+    environment:
+     - POSTGRES_USER="stylometry"
+     - POSTGRES_PASSWORD="password"
+     - POSTGRES_DB="stylometry_database"
+    volumes:
+     - ./db:/var/lib/postgresql/data
+    ports:
+     - 5432:5432
+    profiles:
+     - local
+  
+  authorguard-sqlite:
+    build: stylometryproject
+    ports:
+     - 127.0.0.1:8000:8000
+    environment:
+     - DATABASE_TYPE=sqlite
+    env_file:
+     - secrets/key.env
+    profiles:
+     - test
+    volumes:
+      - stylometryproject/db.sqlite3:/stylometryproject/db.sqlite3

--- a/stylometryproject/stylometryapp/static/scripts/docDisplay.js
+++ b/stylometryproject/stylometryapp/static/scripts/docDisplay.js
@@ -1,4 +1,3 @@
-// Function to update the profile name and documents
 function updateProfileDisplay(profileId) {
 
     // Fetch the selected profile's name using AJAX
@@ -89,13 +88,20 @@ $(document).ready(function () {
 
 // Add a click event listener for delete buttons
 $('#profile-files-list').on('click', '.delete-document-button', function (event) {
+    
     event.preventDefault();
+    var csrftoken = $('input[name=csrfmiddlewaretoken]').val();
+    console.log(csrftoken);
+
     var documentId = $(this).data('documentId');
     var listItem = $(this).closest('li'); // Get the parent list item
 
     // Send an AJAX request to delete the document by its ID
     $.ajax({
         url: '/delete_document/' + documentId + '/',
+        headers: {
+            'X-CSRFToken': csrftoken
+        },
         method: 'DELETE',
         success: function () {
             // Remove the list item as document was deleted from back-end

--- a/stylometryproject/stylometryapp/static/scripts/dropdown.js
+++ b/stylometryproject/stylometryapp/static/scripts/dropdown.js
@@ -9,9 +9,16 @@ $(document).ready(function() {
         // Perform AJAX request to create the new profile
         else{
             console.log("Yes");
+
+            // Get CSRF Token from the hidden input field
+            var csrftoken = $('input[name=csrfmiddlewaretoken]').val();
+
             $.ajax({
                 url: '/create_profile/',  // Update with your Django URL for creating profiles
                 method: 'POST',
+                headers: {
+                    'X-CSRFToken': csrftoken
+                },
                 data: {
                     'name': newProfileName,
                     // TO DO? - any new profiles fields in the future go here

--- a/stylometryproject/stylometryapp/static/scripts/profileManage.js
+++ b/stylometryproject/stylometryapp/static/scripts/profileManage.js
@@ -1,6 +1,9 @@
 $(document).ready(function () {
     // Function to handle profile deletion
     $(".delete-profile").click(function (e) {
+
+        var csrftoken = $('input[name=csrfmiddlewaretoken]').val();
+
         console.log("delete profile clicked");
         e.preventDefault();
         
@@ -15,9 +18,11 @@ $(document).ready(function () {
             $.ajax({
                 type: "POST",
                 url: "/delete_profile/", 
+                headers: {
+                    'X-CSRFToken': csrftoken
+                },
                 data: {
                     profile_id: profileId,
-                    csrfmiddlewaretoken: '{{ csrf_token }}'  
                 },
                 success: function () {
                     // Refresh the page
@@ -51,6 +56,8 @@ $(document).ready(function () {
     $("#editProfileForm").submit(function (e) {
         e.preventDefault();
 
+        var csrftoken = $('input[name=csrfmiddlewaretoken]').val();
+
         // Serialize the form data
         var formData = $(this).serialize();
 
@@ -58,6 +65,9 @@ $(document).ready(function () {
         $.ajax({
             type: "POST",
             url: $(this).attr("action"),
+            headers: {
+                'X-CSRFToken': csrftoken
+            },
             data: formData,
             success: function (data) {
                 // Close the modal

--- a/stylometryproject/stylometryapp/static/scripts/submit.js
+++ b/stylometryproject/stylometryapp/static/scripts/submit.js
@@ -1,7 +1,12 @@
 // Javascript for submit button (ONLY ON PROFILE)
+
 const submitButton = document.getElementById("submit-button");
 if (submitButton) {
     submitButton.addEventListener("click", () => {
+        
+        csrftoken = document.getElementsByName("csrfmiddlewaretoken")[0].value;
+        console.log(csrftoken);
+
         // Get profile ID from docDisplay
         const profileID = $('#curr-profile').data('profile-id');
 
@@ -22,10 +27,10 @@ if (submitButton) {
             return;
         }
 
-
         fetch("/add_profile_docs/", {
             method: "POST",
             headers: {
+                "X-CSRFToken": csrftoken,
                 "Content-Type": "application/json",
             },
             body: JSON.stringify(dataToSend), // Send the modified data

--- a/stylometryproject/stylometryapp/static/scripts/verify.js
+++ b/stylometryproject/stylometryapp/static/scripts/verify.js
@@ -20,7 +20,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (runVerificationButton) {
         runVerificationButton.addEventListener("click", (event) => {
+
             event.preventDefault();
+            var csrftoken = $('input[name=csrfmiddlewaretoken]').val();
 
             // Set a flag in local storage to indicate that the button has been clicked
             localStorage.setItem('buttonClicked', true);
@@ -50,6 +52,7 @@ document.addEventListener("DOMContentLoaded", () => {
             fetch("/run_verify/", {
                 method: "POST",
                 headers: {
+                    "X-CSRFToken": csrftoken,
                     "Content-Type": "application/json",
                 },
                 body: JSON.stringify(dataToSend), // Send the modified data

--- a/stylometryproject/stylometryapp/templates/profile.html
+++ b/stylometryproject/stylometryapp/templates/profile.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 {% load static %}
+{% csrf_token %}
 
 <head>
     <meta charset="UTF-8">

--- a/stylometryproject/stylometryapp/templates/verify.html
+++ b/stylometryproject/stylometryapp/templates/verify.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 {% load static %}
+{% csrf_token %}
 
 <head>
     <meta charset="UTF-8">

--- a/stylometryproject/stylometryapp/views.py
+++ b/stylometryproject/stylometryapp/views.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render, redirect, reverse
 from django.urls import reverse
 from django.http import JsonResponse, HttpResponseRedirect
-from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.csrf import csrf_protect
 
 from django.contrib.auth import login, authenticate
 from django.contrib.auth.forms import UserCreationForm
@@ -64,7 +64,7 @@ def verify_page_view(request):
 
 
 @login_required
-@csrf_exempt
+@csrf_protect
 def create_profile(request):
     """ Creates a new profile """
 
@@ -120,7 +120,7 @@ def get_documents(request, profile_id):
 
 
 @login_required
-@csrf_exempt 
+@csrf_protect
 def add_profile_docs(request):
     """ Adds documents to a profile """
 
@@ -156,7 +156,7 @@ def add_profile_docs(request):
 
 
 @login_required
-@csrf_exempt 
+@csrf_protect
 def delete_profile(request):
     """ Deletes a profile """
 
@@ -177,7 +177,7 @@ def delete_profile(request):
     
 
 @login_required
-@csrf_exempt 
+@csrf_protect
 def edit_profile(request, profile_id):
     """ Edits a profile's name """
 
@@ -196,7 +196,7 @@ def edit_profile(request, profile_id):
 
 
 @login_required
-@csrf_exempt
+@csrf_protect
 def delete_document(request, document_id):
     """ Deletes a document """
 
@@ -211,7 +211,7 @@ def delete_document(request, document_id):
 
 
 @login_required
-@csrf_exempt
+@csrf_protect
 def run_verification(request):
     """ Runs the verification algorithm """
 

--- a/stylometryproject/stylometryproject/settings.py
+++ b/stylometryproject/stylometryproject/settings.py
@@ -112,10 +112,10 @@ match DATABASE_TYPE:
         DATABASES = {
             'default': {
                 'ENGINE': 'django.db.backends.postgresql_psycopg2',
-                'NAME': os.environ.get('RDS_DB_NAME', "stylometry_database"),
-                'USER': os.environ.get('RDS_USERNAME', "postgres"),
-                'PASSWORD': os.environ.get('RDS_PASSWORD', "password"),
-                'HOST': os.environ.get('RDS_HOSTNAME', "localhost"),
+                'NAME': os.environ.get('RDS_DB_NAME', 'stylometry_database'),
+                'USER': os.environ.get('RDS_USERNAME', 'postgres'),
+                'PASSWORD': os.environ.get('RDS_PASSWORD', 'password'),
+                'HOST': os.environ.get('RDS_HOSTNAME', 'localhost'),
                 'PORT': os.environ.get('RDS_PORT', '5432'),
             }
         }

--- a/stylometryproject/stylometryproject/settings.py
+++ b/stylometryproject/stylometryproject/settings.py
@@ -98,7 +98,7 @@ WSGI_APPLICATION = 'stylometryproject.wsgi.application'
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
-DATABASE_TYPE = os.environ['DATABASE_TYPE'] if 'DATABASE_TYPE' in os.environ else "postgres"
+DATABASE_TYPE = os.environ['DATABASE_TYPE'] if 'DATABASE_TYPE' in os.environ else "postgresql"
 
 match DATABASE_TYPE:
     case "sqlite":

--- a/stylometryproject/stylometryproject/settings.py
+++ b/stylometryproject/stylometryproject/settings.py
@@ -15,7 +15,10 @@ import os
 import dotenv
 
 # Load environment variables from .env file
-dotenv.load_dotenv()
+if os.path.isfile(".env"):
+    dotenv.load_dotenv()
+elif os.path.isfile("../secrets.env"):
+    dotenv.load_dotenv("../secrets.env")
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -23,13 +26,13 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Stylometry Model Settings
 STYLOMETRY_PROFILE = "example_profile"
-#STYLOMETRY_PROFILE_BASE = "stylometry_models"
+#STYLOMETRY_PROFILE_DIR = "stylometry_models"
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ['SECRET_KEY']
+SECRET_KEY = os.environ.get('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -95,17 +98,27 @@ WSGI_APPLICATION = 'stylometryproject.wsgi.application'
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
+DATABASE_TYPE = os.environ['DATABASE_TYPE'] if 'DATABASE_TYPE' in os.environ else "postgres"
 
-DATABASES = {
-    'default': {
-        'ENGINE': os.environ['RDS_ENGINE'],
-        'NAME': os.environ['RDS_DB_NAME'],
-        'USER': os.environ['RDS_USERNAME'],
-        'PASSWORD': os.environ['RDS_PASSWORD'],
-        'HOST': os.environ['RDS_HOSTNAME'],
-        'PORT': os.environ['RDS_PORT'],
-    }
-}
+match DATABASE_TYPE:
+    case "sqlite":
+        DATABASES = {
+            'default': {
+                'ENGINE': 'django.db.backends.sqlite3',
+                'NAME': 'db.sqlite3'
+            }
+        }
+    case _: #aka. postgresql
+        DATABASES = {
+            'default': {
+                'ENGINE': 'django.db.backends.postgresql_psycopg2',
+                'NAME': os.environ.get('RDS_DB_NAME', "stylometry_database"),
+                'USER': os.environ.get('RDS_USERNAME', "postgres"),
+                'PASSWORD': os.environ.get('RDS_PASSWORD', "password"),
+                'HOST': os.environ.get('RDS_HOSTNAME', "localhost"),
+                'PORT': os.environ.get('RDS_PORT', '5432'),
+            }
+        }
 
 
 # Password validation

--- a/stylometryproject/stylometryproject/settings.py
+++ b/stylometryproject/stylometryproject/settings.py
@@ -17,8 +17,10 @@ import dotenv
 # Load environment variables from .env file
 if os.path.isfile(".env"):
     dotenv.load_dotenv()
-elif os.path.isfile("../secrets.env"):
-    dotenv.load_dotenv("../secrets.env")
+elif os.path.isdir("../secrets"):
+    for file in os.listdir("../secrets"):
+        if os.path.isfile(os.path.join("../secrets", file)):
+            dotenv.load_dotenv(os.path.join("../secrets", file))
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
+ Changed settings.py to allow more sources of env files
+ Add the compose.yaml file so the `docker compose` command can be used to configure the environment inside the container. Allows changes without needing to recompile, and stops the secret keys and password from having to be compiled into the docker image.
+ Added information to the README on how to use docker compose
+ Added a fallback for an sqlite database via the DATABASE_TYPES env variable, and added some default for the environment so the program doesn't crash without some variables.
+ The original docker method will still work the same, but the compose method should be a bit safer and less cmdline intensive to use.